### PR TITLE
Revert "Sync" as 1.7.0 produces segfaults when X11 starts

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  libinput-1.7.0.tar.xz: f4b7c5322937c46562163934b9988772ccd0e36d
+  libinput-1.6.3.tar.xz: f48799f79ba4235cae8af4c579e3f04e75979375

--- a/libinput.spec
+++ b/libinput.spec
@@ -4,7 +4,7 @@
 
 Summary:	Handles input devices for display servers
 Name:		libinput
-Version:	1.7.0
+Version:	1.6.3
 Release:	1
 License:	LGPLv2
 Group:		System/Libraries


### PR DESCRIPTION
Reverts OpenMandrivaAssociation/libinput#13